### PR TITLE
Add section for sites and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ members or found helpful for managing open source projects and offices.
 - [zanata](https://github.com/zanata/zanata-platform) - Zanata is a web-based system for translators to translate documentation and software online using a web browser.
 - [Weblate](https://weblate.org/) - Weblate is a free web-based translation management system.
 
+## Websites and Documentation
+
+- [Docusaurus](https://docusaurus.io) - Docusaurus is a React-based static site generator, specifically developed to more easily help create and maintain open source websites.
+- [GatsbyJS](https://www.gatsbyjs.org/) - Gatsby is a site generator that allows you to build fast websites and apps with React.
+- [VuePress](https://vuepress.vuejs.org/) - VuePress is a minimalistic Vue-based static site generator, optimized for writing technical documentation.
+
 # License
 
 [![License: CC BY-SA 4.0](https://licensebuttons.net/l/by-sa/4.0/80x15.png)](https://creativecommons.org/licenses/by-sa/4.0/) © Contributors 2016-2018


### PR DESCRIPTION
I believe that mananging an open source project includes having a first-class website and documentation. This PR adds a few popular options for project maintainers to use.