### PR TITLE
Add Pull Request Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ members or found helpful for managing open source projects and offices.
 - [PullApprove](https://www.pullapprove.com) - Allows for fancier rules on how pull requests are approved.
 - [sentinel](https://github.com/habitat-sh/sentinel) - PR Test, review, and merge workflow bot
 - [pull-review](https://github.com/imsky/pull-review) - assign pull request reviewers intelligently, inspired by mention-bot
+- [pull-request-size](https://github.com/noqcks/pull-request-size) - Automatically adds GitHub labels based on the size of a Pull Request.
 
 ## Contributor License Agreements
 


### PR DESCRIPTION
Hey :wave:

I created a little GitHub app based on the Pull Request sizing used by the [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/pulls) project. It helps developers trend towards smaller Pull Request sizes.

I found it useful for myself and would love to share with the world. 