### PR TITLE
Add FOSSID, a license and vulnerability scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ members or found helpful for managing open source projects and offices.
 - [Licensed](https://github.com/github/licensed) - A Ruby gem to cache and verify the licenses of dependencies
 - [LicensePlist](https://github.com/mono0926/LicensePlist) - A command-line tool that automatically generates a Plist of all your dependencies, including files added manually(specified by YAML config file) or using Carthage or CocoaPods.
 - [dpkg-licenses](https://github.com/daald/dpkg-licenses) - A command line tool which lists the licenses of all installed packages in a Debian-based system (like Ubuntu).
+- [FOSSID](https://fossid.com) - A comprehensive commercial scanner for licenses and vulnerabilities.  Knowledgebase covers 78M+ repositories and 600B+ snippets. Includes detailed snippet scanning to detect the license on fragments and copied/pasted code, even if the open source license is not explicitly or correctly declared.
 
 ## Localization and Internationalization
 


### PR DESCRIPTION
Add FOSSID to the list of license scanning tools.  FOSSID is a commercial
scanning tool which has a massive database and comprehensive snippet scanning to
enable detection of copied/pasted code, even if the license declaration has been
removed or is incorrect.

Signed-off-by: Brian Warner <brian@bdwarner.com>