### PR TITLE
Add Maintainer Radar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Tools for managing and automating code review processes.
 - [pull-review](https://github.com/imsky/pull-review) - Assign pull request reviewers intelligently, inspired by mention-bot.
 - [pull-request-size](https://github.com/noqcks/pull-request-size) - Automatically adds GitHub labels based on the size of a pull request.
 - [Pullie](https://github.com/godaddy/pullie) - GitHub App that helps with pull requests (requests reviews, links Jira tickets, reminds users about missing required file changes e.g., changelog entries).
+- [Maintainer Radar](https://github.com/JackSpiece/maintainer-radar) - GitHub Action and local CLI that produces read-only PR triage reports for maintainers.
 
 ## Continuous Integration / Continuous Delivery
 


### PR DESCRIPTION
# Description

Adds Maintainer Radar to the Code Reviews section. It is a GitHub Action and local CLI that produces read-only PR triage reports for maintainers.

## Type of change

- [x] Add a new tool/project
- [ ] Add a new category
- [ ] Documentation update e.g., fixing a broken link, updating an existing entry
- [ ] Other (please describe above)

## New tool/project

### Why is this tool/project needed?

Maintainers often need a quick view of which pull requests may need attention without adding another bot that comments, labels, or mutates repository state. Maintainer Radar helps open source projects and OSPOs generate scheduled, read-only PR triage reports and time-boxed review plans.

### Category Selection

**Selected Category:** Code Reviews

**Why this category?**

The primary use case is helping maintainers review and prioritize pull requests. It fits next to other tools that help manage pull request review workflows.

### Tool Uniqueness

Maintainer Radar is complementary to tools that assign reviewers, add labels, or comment on code. It runs before review to help maintainers decide where attention should go first. Review plans can include editable draft follow-ups for author action, CI fixes, or smaller scope, while the tool itself remains read-only.

## For New Categories

Not applicable.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/todogroup/awesome-ospo/blob/main/CONTRIBUTING.md) guidelines
- [x] I have searched for duplicate suggestions
- [x] The pull request has a descriptive title
- [x] I have added the entry to the bottom of the relevant category (if adding a new tool)
- [x] I have checked my spelling and grammar
- [x] I have removed trailing whitespace
- [x] I have verified that all links work correctly
- [x] I have provided context on why this change is needed above
