### PR TITLE
Add BomLens to Licensing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Tools for managing and tracking open source licenses.
 - [License Classifier](https://github.com/google/licenseclassifier) - A library and set of tools that can analyze text to determine what type of license it contains.
 - [OSS Review Toolkit](https://github.com/oss-review-toolkit/ort) - Enables highly automated and customizable open source compliance checks od the source code and dependencies of a project by scanning it, downloading its sources, reporting any errors and violations against user-defined rules, and by creating third-party attribution documentation.
 - [fossa-cli](https://github.com/fossas/fossa-cli) - Fast, portable and reliable dependency analysis for any codebase.
-- [BomLens](https://github.com/sktelecom/sbom-tools) - Generate CycloneDX SBOMs, open source notice files, and license/security risk reports from source, containers, firmware, and AI models. Runs locally in Docker with a CLI, web UI, and desktop app.
+- [BomLens](https://github.com/sktelecom/bomlens) - Generate CycloneDX SBOMs, open source notice files, and license/security risk reports from source, containers, firmware, and AI models. Runs locally in Docker with a CLI, web UI, and desktop app.
 - [Licensed](https://github.com/licensee/licensed) - A Ruby gem to cache and verify the licenses of dependencies.
 - [LicensePlist](https://github.com/mono0926/LicensePlist) - A command-line tool that automatically generates a Plist of all your dependencies, including files added manually (specified by YAML config file) or using Carthage or CocoaPods.
 - [dpkg-licenses](https://github.com/daald/dpkg-licenses) - A command line tool which lists the licenses of all installed packages in a Debian-based system (like Ubuntu).

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Tools for managing and tracking open source licenses.
 - [License Classifier](https://github.com/google/licenseclassifier) - A library and set of tools that can analyze text to determine what type of license it contains.
 - [OSS Review Toolkit](https://github.com/oss-review-toolkit/ort) - Enables highly automated and customizable open source compliance checks od the source code and dependencies of a project by scanning it, downloading its sources, reporting any errors and violations against user-defined rules, and by creating third-party attribution documentation.
 - [fossa-cli](https://github.com/fossas/fossa-cli) - Fast, portable and reliable dependency analysis for any codebase.
+- [BomLens](https://github.com/sktelecom/sbom-tools) - Generate CycloneDX SBOMs, open source notice files, and license/security risk reports from source, containers, firmware, and AI models. Runs locally in Docker with a CLI, web UI, and desktop app.
 - [Licensed](https://github.com/licensee/licensed) - A Ruby gem to cache and verify the licenses of dependencies.
 - [LicensePlist](https://github.com/mono0926/LicensePlist) - A command-line tool that automatically generates a Plist of all your dependencies, including files added manually (specified by YAML config file) or using Carthage or CocoaPods.
 - [dpkg-licenses](https://github.com/daald/dpkg-licenses) - A command line tool which lists the licenses of all installed packages in a Debian-based system (like Ubuntu).


### PR DESCRIPTION
Adds BomLens (https://github.com/sktelecom/sbom-tools) to the Licensing tools list.

BomLens is an open source (Apache-2.0) tool by SK Telecom that generates CycloneDX SBOMs, open source notice files, and license/security risk reports from source code, containers, binaries, firmware, and HuggingFace AI models. It runs locally in Docker with a CLI, web UI, and desktop app — built for OSPO-style compliance work (SPDX-normalized license ids, notice generation, license risk reporting) without sending code anywhere.